### PR TITLE
Implement recording/TTS site with Coqui server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # ReverseNumber9
 
-ReverseNumber9 instantly reverses TTS‑generated speech and uploaded voice recordings in your browser, offering real‑time playback and easy downloads.
+ReverseNumber9 instantly reverses TTS-generated speech and recorded audio in your browser. You can record audio, play it normally or reversed, and download the result. Text entered on the page is synthesized with a self-hosted Coqui TTS server and can also be played forward or backward.
+
+## Setup
+
+1. Install Python dependencies (preferably in a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the TTS server:
+   ```bash
+   python tts_server.py
+   ```
+   The server provides a `/tts?text=...` endpoint returning a WAV file.
+
+3. Open `static/index.html` in your browser. Use HTTPS or serve the files with a local web server if your browser blocks microphone access over `file://`.
+
+## Features
+
+- Record audio in the browser and play or download it normally or reversed.
+- Enter text which is synthesized using Coqui TTS and played back forward or backward.
+- Download links are provided for both recorded and synthesized audio.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+TTS
+scipy

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ReverseNumber9</title>
+<style>
+button { margin: 5px; }
+</style>
+</head>
+<body>
+<h1>ReverseNumber9</h1>
+<section>
+<h2>Record</h2>
+<button id="recordBtn">Start Recording</button>
+<button id="stopBtn" disabled>Stop Recording</button>
+<button id="playBtn" disabled>Play</button>
+<button id="reversePlayBtn" disabled>Play Reversed</button>
+<a id="downloadLink" download="recording.wav" style="display:none">Download</a>
+</section>
+<section>
+<h2>Text to Speech</h2>
+<textarea id="ttsText" rows="3" cols="40" placeholder="Enter text..."></textarea><br>
+<button id="ttsBtn">Synthesize</button>
+<button id="ttsPlayBtn" disabled>Play TTS</button>
+<button id="ttsReversePlayBtn" disabled>Play TTS Reversed</button>
+<a id="ttsDownloadLink" download="tts.wav" style="display:none">Download TTS</a>
+</section>
+<script>
+let mediaRecorder;
+let recordedChunks = [];
+let recordedBlob;
+
+const recordBtn = document.getElementById('recordBtn');
+const stopBtn = document.getElementById('stopBtn');
+const playBtn = document.getElementById('playBtn');
+const reversePlayBtn = document.getElementById('reversePlayBtn');
+const downloadLink = document.getElementById('downloadLink');
+
+recordBtn.onclick = async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  mediaRecorder = new MediaRecorder(stream);
+  recordedChunks = [];
+  mediaRecorder.ondataavailable = e => recordedChunks.push(e.data);
+  mediaRecorder.onstop = e => {
+    recordedBlob = new Blob(recordedChunks);
+    playBtn.disabled = false;
+    reversePlayBtn.disabled = false;
+    downloadLink.href = URL.createObjectURL(recordedBlob);
+    downloadLink.style.display = 'inline';
+  };
+  mediaRecorder.start();
+  recordBtn.disabled = true;
+  stopBtn.disabled = false;
+};
+
+stopBtn.onclick = () => {
+  mediaRecorder.stop();
+  recordBtn.disabled = false;
+  stopBtn.disabled = true;
+};
+
+function playBlobReversed(blob) {
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  blob.arrayBuffer().then(buf => audioCtx.decodeAudioData(buf, audioBuf => {
+    for (let i = 0; i < audioBuf.numberOfChannels; i++) {
+      Array.prototype.reverse.call(audioBuf.getChannelData(i));
+    }
+    const source = audioCtx.createBufferSource();
+    source.buffer = audioBuf;
+    source.connect(audioCtx.destination);
+    source.start();
+  }));
+}
+
+playBtn.onclick = () => {
+  const url = URL.createObjectURL(recordedBlob);
+  new Audio(url).play();
+};
+
+reversePlayBtn.onclick = () => {
+  playBlobReversed(recordedBlob);
+};
+
+// TTS
+let ttsBlob;
+const ttsBtn = document.getElementById('ttsBtn');
+const ttsPlayBtn = document.getElementById('ttsPlayBtn');
+const ttsReversePlayBtn = document.getElementById('ttsReversePlayBtn');
+const ttsDownloadLink = document.getElementById('ttsDownloadLink');
+
+ttsBtn.onclick = () => {
+  const text = document.getElementById('ttsText').value;
+  fetch(`/tts?text=${encodeURIComponent(text)}`)
+    .then(r => r.blob())
+    .then(b => {
+      ttsBlob = b;
+      ttsPlayBtn.disabled = false;
+      ttsReversePlayBtn.disabled = false;
+      ttsDownloadLink.href = URL.createObjectURL(ttsBlob);
+      ttsDownloadLink.style.display = 'inline';
+    });
+};
+
+ttsPlayBtn.onclick = () => {
+  const url = URL.createObjectURL(ttsBlob);
+  new Audio(url).play();
+};
+
+ttsReversePlayBtn.onclick = () => {
+  playBlobReversed(ttsBlob);
+};
+</script>
+</body>
+</html>

--- a/tts_server.py
+++ b/tts_server.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, send_file
+from TTS.api import TTS
+import io
+from scipy.io.wavfile import write as wav_write
+
+app = Flask(__name__)
+
+# Load default English model. Adjust model name as needed.
+TTS_MODEL = TTS(model_name="tts_models/en/ljspeech/tacotron2-DDC", progress_bar=False, gpu=False)
+
+@app.route('/tts')
+def tts_route():
+    text = request.args.get('text', '').strip()
+    if not text:
+        return 'No text', 400
+    wav = TTS_MODEL.tts(text)
+    memfile = io.BytesIO()
+    wav_write(memfile, TTS_MODEL.synthesizer.output_sample_rate, wav)
+    memfile.seek(0)
+    return send_file(memfile, mimetype='audio/wav')
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add an HTML client for recording, reversing and playing audio
- implement a small Flask server using Coqui TTS
- document setup steps
- add Python dependency list

## Testing
- `python -m py_compile tts_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6878594fb50c832b810f78e455c91334