### PR TITLE
Add workflow to start TTS server

### DIFF
--- a/.github/workflows/start-server.yml
+++ b/.github/workflows/start-server.yml
@@ -1,0 +1,28 @@
+name: Start Server
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  start-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Start server
+        run: |
+          python tts_server.py &
+          PID=$!
+          sleep 15
+          curl -I http://127.0.0.1:5000/tts?text=hello
+          kill $PID


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to boot the Flask TTS server and hit `/tts` endpoint

## Testing
- `python -m py_compile tts_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785ae80acc832b87bd069ea1ed89ea