### PR TITLE
Add PORT env to workflow and server

### DIFF
--- a/.github/workflows/start-server.yml
+++ b/.github/workflows/start-server.yml
@@ -1,0 +1,29 @@
+name: Start Server
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  start-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Start server
+        run: |
+          export PORT=5000
+          python tts_server.py &
+          PID=$!
+          sleep 15
+          curl -I http://127.0.0.1:$PORT/tts?text=hello
+          kill $PID

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ ReverseNumber9 instantly reverses TTS-generated speech and recorded audio in you
    ```bash
    pip install -r requirements.txt
    ```
-2. Start the TTS server:
+2. Start the TTS server (optionally set `PORT` to choose the port):
    ```bash
-   python tts_server.py
+   PORT=5000 python tts_server.py
    ```
-   The server provides a `/tts?text=...` endpoint returning a WAV file.
+   The server listens on `0.0.0.0:$PORT` and provides a `/tts?text=...` endpoint returning a WAV file.
 
 3. Open `static/index.html` in your browser. Use HTTPS or serve the files with a local web server if your browser blocks microphone access over `file://`.
 

--- a/tts_server.py
+++ b/tts_server.py
@@ -20,4 +20,6 @@ def tts_route():
     return send_file(memfile, mimetype='audio/wav')
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- allow customizing port for TTS server
- update workflow to use PORT env variable
- document server port usage

## Testing
- `python -m py_compile tts_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68785ae80acc832b87bd069ea1ed89ea