### PR TITLE
Add 404 to sitemap

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -6,4 +6,7 @@
   <url>
     <loc>https://cheesedongjin.github.io/ReverseNumber9/other-sites/addresses.html</loc>
   </url>
+  <url>
+    <loc>https://cheesedongjin.github.io/ReverseNumber9/404.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- update `static/sitemap.xml` so that the 404 page is included in the sitemap

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68786e2a98bc832b8f0a73542146ce2d