### PR TITLE
Remove html extension from sitemap

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -4,6 +4,6 @@
     <loc>https://cheesedongjin.github.io/ReverseNumber9/</loc>
   </url>
   <url>
-    <loc>https://cheesedongjin.github.io/ReverseNumber9/other-sites/addresses.html</loc>
+    <loc>https://cheesedongjin.github.io/ReverseNumber9/other-sites/addresses</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- update sitemap.xml to omit `.html` in the addresses page URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68786f5fa308832b8df7358c4143b278