### PR TITLE
Add record/stop toggle button, align play controls

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -48,33 +48,28 @@
 
             <div class="controls">
                 <button class="btn btn-primary" id="recordBtn">
-                    <svg class="icon" viewBox="0 0 24 24">
+                    <svg class="icon" id="recordIcon" viewBox="0 0 24 24">
                         <circle cx="12" cy="12" r="10"/>
                         <circle cx="12" cy="12" r="3"/>
                     </svg>
-                    Start Recording
+                    <span id="recordBtnText">Start Recording</span>
                 </button>
 
-                <button class="btn btn-danger" id="stopBtn" disabled>
-                    <svg class="icon" viewBox="0 0 24 24">
-                        <rect x="9" y="9" width="6" height="6"/>
-                    </svg>
-                    Stop Recording
-                </button>
+                <div class="play-controls">
+                    <button class="btn btn-success" id="playBtn" disabled>
+                        <svg class="icon" viewBox="0 0 24 24">
+                            <polygon points="5,3 19,12 5,21"/>
+                        </svg>
+                        Play Original
+                    </button>
 
-                <button class="btn btn-success" id="playBtn" disabled>
-                    <svg class="icon" viewBox="0 0 24 24">
-                        <polygon points="5,3 19,12 5,21"/>
-                    </svg>
-                    Play Original
-                </button>
-
-                <button class="btn btn-success" id="reversePlayBtn" disabled>
-                    <svg class="icon" viewBox="0 0 24 24">
-                        <polygon points="19,3 5,12 19,21"/>
-                    </svg>
-                    Play Reversed
-                </button>
+                    <button class="btn btn-success" id="reversePlayBtn" disabled>
+                        <svg class="icon" viewBox="0 0 24 24">
+                            <polygon points="19,3 5,12 19,21"/>
+                        </svg>
+                        Play Reversed
+                    </button>
+                </div>
             </div>
 
             <div class="downloads">
@@ -121,7 +116,8 @@
 
             initializeElements() {
                 this.recordBtn = document.getElementById('recordBtn');
-                this.stopBtn = document.getElementById('stopBtn');
+                this.recordIcon = document.getElementById('recordIcon');
+                this.recordBtnText = document.getElementById('recordBtnText');
                 this.playBtn = document.getElementById('playBtn');
                 this.reversePlayBtn = document.getElementById('reversePlayBtn');
                 this.downloadLink = document.getElementById('downloadLink');
@@ -147,11 +143,15 @@
             }
 
             attachEventListeners() {
+                this.isRecording = false;
                 this.recordBtn.addEventListener('click', () => {
                     this.stopCurrentAudio();
-                    this.startRecording();
+                    if (this.isRecording) {
+                        this.stopRecording();
+                    } else {
+                        this.startRecording();
+                    }
                 });
-                this.stopBtn.addEventListener('click', () => this.stopRecording());
                 this.playBtn.addEventListener('click', () => this.playOriginal());
                 this.reversePlayBtn.addEventListener('click', () => this.playReversed());
             }
@@ -255,8 +255,11 @@
                     // Start visualization
                     this.drawWaveform();
 
-                    this.recordBtn.disabled = true;
-                    this.stopBtn.disabled = false;
+                    this.isRecording = true;
+                    this.recordBtn.classList.remove('btn-primary');
+                    this.recordBtn.classList.add('btn-danger');
+                    this.recordBtnText.textContent = 'Stop Recording';
+                    this.recordIcon.innerHTML = '<rect x="9" y="9" width="6" height="6"/>';
                     this.playBtn.disabled = true;
                     this.reversePlayBtn.disabled = true;
 
@@ -278,8 +281,11 @@
                 }
 
                 this.stopTimer();
-                this.recordBtn.disabled = false;
-                this.stopBtn.disabled = true;
+                this.isRecording = false;
+                this.recordBtn.classList.remove('btn-danger');
+                this.recordBtn.classList.add('btn-primary');
+                this.recordBtnText.textContent = 'Start Recording';
+                this.recordIcon.innerHTML = '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/>';
             }
 
             async processRecording() {

--- a/static/style.css
+++ b/static/style.css
@@ -177,10 +177,18 @@ body::before {
 }
 
 .controls {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     gap: 1.5rem;
     margin-bottom: 2rem;
+}
+
+.play-controls {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .btn {
@@ -366,7 +374,5 @@ body::before {
         margin: 1rem;
     }
 
-    .controls {
-        grid-template-columns: 1fr;
-    }
+    /* Keep play buttons side by side on small screens */
 }


### PR DESCRIPTION
## Summary
- replace separate record and stop buttons with one toggle button
- keep play and reverse play buttons side-by-side
- tweak CSS for new control layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68798556ab64832bb6fda5cdbb1b4ba7